### PR TITLE
the package "tftpd" conflicts with the "tftpd-hpa"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ First install the needed dependencies by opening a terminal and running the foll
 
 ```
 sudo -s
-apt-get install tofrodos gawk xvfb git libncurses5-dev tftpd zlib1g-dev zlib1g-dev:i386  \
+apt-get install tofrodos gawk xvfb git libncurses5-dev zlib1g-dev zlib1g-dev:i386  \
                 libssl-dev flex bison chrpath socat autoconf libtool texinfo gcc-multilib \
                 libsdl1.2-dev libglib2.0-dev screen pax 
 reboot


### PR DESCRIPTION
LANG=C apt-get install tftpd-hpa
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following package was automatically installed and is no longer required:
  xinetd
Use 'sudo apt autoremove' to remove it.
Suggested packages:
  pxelinux
The following packages will be REMOVED:
  tftpd
The following NEW packages will be installed:
  tftpd-hpa
0 upgraded, 1 newly installed, 1 to remove and 0 not upgraded.
Need to get 0 B/39.1 kB of archives.
After this operation, 32.8 kB of additional disk space will be used.
Do you want to continue? [Y/n] 
Preconfiguring packages ...
(Reading database ... 177239 files and directories currently installed.)
Removing tftpd (0.17-18ubuntu2) ...
Processing triggers for man-db (2.7.5-1) ...
Selecting previously unselected package tftpd-hpa.
(Reading database ... 177233 files and directories currently installed.)
Preparing to unpack .../tftpd-hpa_5.2+20150808-1ubuntu1.16.04.1_amd64.deb ...
Unpacking tftpd-hpa (5.2+20150808-1ubuntu1.16.04.1) ...
Processing triggers for ureadahead (0.100.0-19) ...
Processing triggers for systemd (229-4ubuntu21.17) ...
Processing triggers for man-db (2.7.5-1) ...
Setting up tftpd-hpa (5.2+20150808-1ubuntu1.16.04.1) ...